### PR TITLE
Resolved the issue for twice footer on homepage

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -350,7 +350,7 @@ const MotionButton = motion(Button);
         </section>
       </main>
 
-      <Footer />
+      {/* <Footer /> Removed to prevent duplicate footer */}
     </>
   )
 }


### PR DESCRIPTION
### Problem:
On the homepage, the footer section was being rendered twice due to redundant component inclusion or layout logic.

### Fix:
- Identified and removed the duplicate rendering of the `Footer` component.
- Ensured the footer now appears only once on the homepage layout.
- Verified that other pages using the footer are unaffected by this change.
#35 
Before :
![Screenshot 2025-05-18 112647](https://github.com/user-attachments/assets/dbe8a5c0-5ffc-4248-94ac-6359337515cd)
After : 
![Screenshot 2025-05-18 112723](https://github.com/user-attachments/assets/e7894901-8bc0-40b2-aa60-18f092b897ba)

### Impact:
Improves UI clarity and avoids unnecessary repetition in the homepage layout.

Let me know if any additional cleanup or layout changes are needed!
